### PR TITLE
Fix ESLint issues

### DIFF
--- a/app/favorites/page.tsx
+++ b/app/favorites/page.tsx
@@ -5,9 +5,10 @@ import FavoriteButton from '@/components/favorite/FavoriteButton';
 import Link from 'next/link';
 import '../list/ToiletList.css';
 import './FavoritePage.css';
+import type { Toilet } from '@/context/ToiletContext';
 
 export default function FavoritePage() {
-  const [favorites, setFavorites] = useState<any[]>([]);
+  const [favorites, setFavorites] = useState<Toilet[]>([]);
   const [removingIds, setRemovingIds] = useState<string[]>([]);
 
   useEffect(() => {

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -7,6 +7,8 @@ import { useToilet } from '@/context/ToiletContext';
 import { useSearchParams } from 'next/navigation';
 
 declare global {
+  // kakao map library does not provide TypeScript types
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   interface Window {
     kakao: any;
   }
@@ -23,12 +25,37 @@ const FILTERS = [
   '냄새 좋음',
 ];
 
+interface KakaoPlace {
+  id: string;
+  place_name: string;
+  x: string;
+  y: string;
+  [key: string]: unknown;
+}
+
+interface ToiletDbData {
+  overallRating?: number;
+  reviews?: unknown[];
+  keywords?: string[];
+}
+
+interface EnrichedToilet extends KakaoPlace {
+  overallRating: number;
+  reviews: unknown[];
+  keywords: string[];
+}
+
+interface KakaoMap {
+  setCenter: (latlng: unknown) => void;
+  panTo: (latlng: unknown) => void;
+}
+
 export default function MapView() {
   const { setToiletList } = useToilet();
-  const mapRef = useRef<any>(null);
+  const mapRef = useRef<KakaoMap | null>(null);
   const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
-  const [allToilets, setAllToilets] = useState<any[]>([]);
-  const [markers, setMarkers] = useState<any[]>([]);
+  const [allToilets, setAllToilets] = useState<EnrichedToilet[]>([]);
+  const [markers, setMarkers] = useState<Array<{ setMap: (map: unknown | null) => void }>>([]);
   const [showFilters, setShowFilters] = useState(false);
   const searchParams = useSearchParams();
   const queryKeyword = searchParams?.get('query');
@@ -68,7 +95,7 @@ export default function MapView() {
       level: 3,
     });
 
-    mapRef.current = map;
+    mapRef.current = map as unknown as KakaoMap;
     searchToilets(lat, lng);
   };
 
@@ -77,16 +104,16 @@ export default function MapView() {
     geocoder.addressSearch(
       keyword,
       (
-      result: {
+      result: Array<{
         x: string;
         y: string;
-        [key: string]: any;
-      }[],
+        [key: string]: unknown;
+      }>,
       status: string
       ) => {
       if (status === window.kakao.maps.services.Status.OK) {
         const coords = new window.kakao.maps.LatLng(Number(result[0].y), Number(result[0].x));
-        mapRef.current.setCenter(coords);
+        (mapRef.current as KakaoMap).setCenter(coords);
         searchToilets(Number(result[0].y), Number(result[0].x));
       } else {
         alert('검색 결과가 없습니다.');
@@ -95,12 +122,12 @@ export default function MapView() {
     );
   };
 
-  const renderMarkers = (toilets: any[]) => {
+  const renderMarkers = (toilets: EnrichedToilet[]) => {
     markers.forEach((marker) => marker.setMap(null));
     setMarkers([]);
 
-    let currentOverlay: any = null;
-    const newMarkers: any[] = [];
+    let currentOverlay: unknown = null;
+    const newMarkers: Array<{ setMap: (map: unknown | null) => void }> = [];
 
     toilets.forEach((place) => {
       const position = new window.kakao.maps.LatLng(place.y, place.x);
@@ -114,7 +141,7 @@ export default function MapView() {
 
       // ✅ 이미지 마커로 생성
       const marker = new window.kakao.maps.Marker({
-        map: mapRef.current,
+        map: mapRef.current as unknown as KakaoMap,
         position,
         image: markerImage,
       });
@@ -144,9 +171,9 @@ export default function MapView() {
       });
 
       window.kakao.maps.event.addListener(marker, 'click', () => {
-        mapRef.current.panTo(position);
+        (mapRef.current as KakaoMap).panTo(position);
         if (currentOverlay) currentOverlay.setMap(null);
-        overlay.setMap(mapRef.current);
+        overlay.setMap(mapRef.current as unknown as KakaoMap);
         currentOverlay = overlay;
 
         setTimeout(() => {
@@ -162,25 +189,6 @@ export default function MapView() {
 
   const searchToilets = async (lat: number, lng: number) => {
     const ps = new window.kakao.maps.services.Places();
-    interface KakaoPlace {
-      id: string;
-      place_name: string;
-      x: string;
-      y: string;
-      [key: string]: any;
-    }
-
-    interface ToiletDbData {
-      overallRating?: number;
-      reviews?: any[];
-      keywords?: string[];
-    }
-
-    interface EnrichedToilet extends KakaoPlace {
-      overallRating: number;
-      reviews: any[];
-      keywords: string[];
-    }
 
     ps.keywordSearch(
       '화장실',

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,7 @@ import type { NextConfig } from "next";
 
 const nextConfig = {
   /* config options here */
-    webpack(config: any) {
+    webpack(config: NextConfig) {
     config.resolve.alias = {
       ...(config.resolve.alias || {}),
       '@': path.resolve(__dirname),

--- a/pages/api/favorite/list.ts
+++ b/pages/api/favorite/list.ts
@@ -16,6 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const decoded = jwt.verify(token, JWT_SECRET) as { userId: string };
     userId = decoded.userId;
   } catch (err) {
+    console.error(err);
     return res.status(401).json({ message: '유효하지 않은 토큰입니다.' });
   }
 

--- a/pages/api/favorite/status.ts
+++ b/pages/api/favorite/status.ts
@@ -16,6 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const decoded = jwt.verify(token, JWT_SECRET) as { userId: string };
     userId = decoded.userId;
   } catch (error) {
+    console.error(error);
     return res.status(401).json({ message: '유효하지 않은 토큰입니다.' });
   }
 

--- a/pages/api/favorite/toggle.ts
+++ b/pages/api/favorite/toggle.ts
@@ -23,6 +23,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const decoded = jwt.verify(token, JWT_SECRET) as { userId: string };
     userId = decoded.userId;
   } catch (error) {
+    console.error(error);
     return res.status(401).json({ message: '유효하지 않은 토큰입니다.' });
   }
 

--- a/pages/api/toilet/[id].ts
+++ b/pages/api/toilet/[id].ts
@@ -32,9 +32,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     await db.collection('toilets').insertOne(toilet);
   }
 
-  const parseDecimal = (v: any): number | undefined => {
-    if (typeof v === 'object' && v?.$numberDecimal) {
-      return parseFloat(v.$numberDecimal);
+  const parseDecimal = (v: unknown): number | undefined => {
+    if (
+      typeof v === 'object' &&
+      v !== null &&
+      '$numberDecimal' in v &&
+      typeof (v as { $numberDecimal: string }).$numberDecimal === 'string'
+    ) {
+      return parseFloat((v as { $numberDecimal: string }).$numberDecimal);
     }
     return typeof v === 'number' ? v : undefined;
   };

--- a/pages/api/toilet/[id]/comment/delete.ts
+++ b/pages/api/toilet/[id]/comment/delete.ts
@@ -1,7 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { connectDB } from '@/util/database';
 import jwt from 'jsonwebtoken';
-import { ObjectId } from 'mongodb';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -19,6 +18,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const decoded = jwt.verify(token, JWT_SECRET) as { userId: string };
     userId = decoded.userId;
   } catch (error) {
+    console.error(error);
     return res.status(401).json({ message: '유효하지 않은 토큰' });
   }
 

--- a/pages/api/toilet/[id]/rate.ts
+++ b/pages/api/toilet/[id]/rate.ts
@@ -63,7 +63,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     return res.status(200).json({ success: true, result });
   } catch (err) {
-    // console.error('🚨 별점 등록 실패:', err);
+    console.error('🚨 별점 등록 실패:', err);
     return res.status(500).json({ error: '업데이트 실패' });
   }
 }


### PR DESCRIPTION
## Summary
- address explicit `any` usage in Favorite page and MapView
- log errors in API routes instead of keeping unused vars
- refine decimal parsing for toilet API
- adjust next config type

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fcc5da73c832ba101fcde6d243d9b